### PR TITLE
Added djedditt/tiled-to-gba-export to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ npx eslint [your-extension.js]
 
 ### JavaScript
 
+* [djedditt/tiled-to-gba-export](https://github.com/djedditt/tiled-to-gba-export)
 * [MikeMnD/tiled-to-godot-export](https://github.com/MikeMnD/tiled-to-godot-export)
 * [ilius33/TiledToAngbandExport](https://github.com/ilius33/TiledToAngbandExport)
 * [sergkr/tiled-bulk-animations](https://github.com/sergkr/tiled-bulk-animations)


### PR DESCRIPTION
This extension adds the "GBA source files" type to the "Export As" menu, which generates a .c source file and associated .h header file. The source file contains special formatted arrays (one per tile layer) that can be loaded directly into GBA VRAM for use as regular (not affine) tiled backgrounds. Only valid GBA map sizes can be exported.